### PR TITLE
Update react-native-libraries.json add "@rn-vui/ratings"

### DIFF
--- a/react-native-libraries.json
+++ b/react-native-libraries.json
@@ -14727,5 +14727,19 @@
       "https://github.com/alanjhughes/expo-shazamkit/tree/main/example"
     ],
     "ios": true
+  },
+  {
+    "githubUrl": "https://github.com/deepktp/react-native-vikalp-ratings",
+    "npmPkg": "@rn-vui/ratings",
+    "images": [
+      "https://raw.githubusercontent.com/deepktp/react-native-vikalp-ratings/master/resources/tap_rating_1.png",
+      "https://raw.githubusercontent.com/deepktp/react-native-vikalp-ratings/master/resources/tap_rating_2.png",
+      "https://raw.githubusercontent.com/deepktp/react-native-viaklp-ratings/master/resources/swipe_rating_1.png",
+      "https://raw.githubusercontent.com/deepktp/react-native-vikalp-ratings/master/resources/swipe_rating_2.png"
+    ],
+    "ios": true,
+    "android": true,
+    "web": true,
+    "expoGo": true
   }
 ]


### PR DESCRIPTION
Added new library `@rn-vui/ratings` forked from `react-native-ratings` that is not updated in last 4 years on NPM and no update on github from last year. Also original library does not work with React Native 0.79 .

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. 
Please follow the template so that the reviewers can easily understand what the code changes affect -->

# 📝 Why & how
<!-- Does this PR add a feature? Address a bug? Add a new library? Document your changes here! -->


# ✅ Checklist
<!-- Check completed item, when applicable, via [X], remove unneeded tasks from the list -->

<!-- If you added a new library or updated the existing one -->
- [X ] Added library to **`react-native-libraries.json`**
- [ ] Updated library in **`react-native-libraries.json`**

